### PR TITLE
updated README with new connection methods directly from host

### DIFF
--- a/cockroach-gssapi-multinode/docker-compose.yml
+++ b/cockroach-gssapi-multinode/docker-compose.yml
@@ -110,8 +110,9 @@ services:
     container_name: client
     hostname: client
     build: ./client
-    extra_hosts:
-      - "lb:172.28.0.6"
+    # this is no longer necessary to populate /etc/hosts, cockroach binary connects just fine
+    #extra_hosts:
+    #  - "lb:172.28.0.6"
     depends_on:
       - lb
       - roach-cert


### PR DESCRIPTION
removed hosts entry `lb` in /etc/hosts as `cockroach` does not need it, it breaks `psql` though